### PR TITLE
Use _R_CHECK_LENGTH_1_CONDITION_ for .Renviron exercise

### DIFF
--- a/01_startup_comfy.R
+++ b/01_startup_comfy.R
@@ -1,28 +1,26 @@
 #' Working with the .Renviron file
 
-## We will be generating a Github Personal Access Token (PAT), adding it to
-## your .Renviron file, creating a new project, commiting it with git and then
-## using our PAT to uploading it to GitHub.
+## We will be editing the .Renviron to make R be strict about checking
+## conditions with length greater than 1.
 
-## The following functions from the `usethis` package will be very useful for this.
-
-- usethis::use_readme_md()
-- usethis::create_project()
-- usethis::browse_github_pat()
-- usethis::use_git()
-- usethis::use_github()
+## The following function from the `usethis` package may be helpful for this:
 - usethis::edit_r_environ()
 
-#' Generate a GitHub Personal Access Token
-## Be sure to check the scopes to allow creation of new repositories
+#' As an example, take the following vector and check if the values are > 0.
+x <- c(1, -2)
 
-#' Add a GitHub Personal Access Token to your .Renviron
-## The environment variable should be called `GITHUB_PAT`
+#' Write an if-statement that prints "Positive" if x is greater than 0
+## and "Negative" if it's < 0. You will see a warning; that is ok!
 
-#' Create a new project
+## if ( # <some condition>) {
+##   # <something here>
+## } else if ( # <some other condition>) {
+##   # <something here>
+## }
 
-#' Create a README.md in your new project
+#' Edit your .Renviron
+## Add the following: _R_CHECK_LENGTH_1_CONDITION_=true
 
-#' Commit the changes in git
+#' Restart R
 
-#' Push the project to GitHub
+#' Run the code to print Positive/Negative again

--- a/01_startup_jim.R
+++ b/01_startup_jim.R
@@ -1,34 +1,30 @@
 #' Working with the .Renviron file
 
-## We will be generating a Github Personal Access Token (PAT), adding it to
-## your .Renviron file, creating a new project, commiting it with git and then
-## using our PAT to uploading it to GitHub.
+## We will be editing the .Renviron to make R be strict about checking
+## conditions with length greater than 1.
 
-## The following functions from the `usethis` package will be very useful for this.
+#' As an example, take the following vector and check if the values are > 0.
+x <- c(1, -2)
 
-- usethis::use_readme_md()
-- usethis::create_project()
-- usethis::browse_github_pat()
-- usethis::use_git()
-- usethis::use_github()
-- usethis::edit_r_environ()
+#' Write an if-statement that prints "Positive" if x is greater than 0
+## and "Negative" if it's < 0. You will see a warning; that is ok!
+if (x > 0) {
+  print("Positive")
+} else if (x < 0) {
+  print("Negative")
+}
 
-#' Generate a GitHub Personal Access Token
-## Be sure to check the scopes to allow creation of new repositories
-usethis::browse_github_pat()
-
-#' Add a GitHub Personal Access Token to your .Renviron
-## The environment variable should be called `GITHUB_PAT`
+#' Edit your .Renviron
+## Add the following: _R_CHECK_LENGTH_1_CONDITION_=true
 usethis::edit_r_environ()
 
-#' Create a new project
-usethis::create_project("wtf")
+#' Restart R
 
-#' Create a README.md in your new project
-usethis::use_readme_md()
+#' Run the code to print Positive/Negative again
+x <- c(1, -2)
 
-#' Commit the changes in git
-usethis::use_git()
-
-#' Push the project to GitHub
-usethis::use_github()
+if (x > 0) {
+  print("Positive")
+} else if (x < 0) {
+  print("Negative")
+}

--- a/01_startup_spartan.R
+++ b/01_startup_spartan.R
@@ -1,21 +1,19 @@
 #' Working with the .Renviron file
 
-## We will be generating a Github Personal Access Token (PAT), adding it to
-## your .Renviron file, creating a new project, commiting it with git and then
-## using our PAT to uploading it to GitHub.
+## We will be editing the .Renviron to make R be strict about checking
+## conditions with length greater than 1.
 
-## functions from the `usethis` package will be very useful for this.
+## There is a function in the usethis package to edit your .Renviron.
 
-#' Generate a GitHub Personal Access Token
-## Be sure to check the scopes to allow creation of new repositories
+#' As an example, take the following vector and check if the values are > 0.
+x <- c(1, -2)
 
-#' Add a GitHub Personal Access Token to your .Renviron
-## The environment variable should be called `GITHUB_PAT`
+#' Write an if-statement that prints "Positive" if x is greater than 0
+## and "Negative" if it's < 0. You will see a warning; that is ok!
 
-#' Create a new project
+#' Edit your .Renviron
+## Add the following: _R_CHECK_LENGTH_1_CONDITION_=true
 
-#' Create a README.md in your new project
+#' Restart R
 
-#' Commit the changes in git
-
-#' Push the project to GitHub
+#' Run the code to print Positive/Negative again


### PR DESCRIPTION
Since setting up a GitHub PAT is now part of the pre-workshop setup, I updated the .Renviron exercise to walk through setting `_R_CHECK_LENGTH_1_CONDITION_` and showing how it changes R's behavior. I did this with R-Ladies and it worked okay. We also talked about risks when doing this (i.e. if there are length > 1 conditions in code you don't control) and how to turn this back off if needed.